### PR TITLE
Sqoop logging fixes

### DIFF
--- a/bin/configure-sqoop
+++ b/bin/configure-sqoop
@@ -72,12 +72,12 @@ fi
 
 # We are setting HADOOP_HOME to HADOOP_COMMON_HOME if it is not set
 # so that hcat script works correctly on BigTop
-#if [ -z "${HADOOP_HOME}" ]; then
-#  if [ -n "${HADOOP_COMMON_HOME}" ]; then
-#     HADOOP_HOME=${HADOOP_COMMON_HOME}
-#     export HADOOP_HOME
-#  fi
-#fi
+if [ -z "${HADOOP_HOME}" ]; then
+  if [ -n "${HADOOP_COMMON_HOME}" ]; then
+     HADOOP_HOME=${HADOOP_COMMON_HOME}
+     export HADOOP_HOME
+  fi
+fi
 
 if [ -z "${HBASE_HOME}" ]; then
   if [ -d "/usr/lib/hbase" ]; then

--- a/bin/configure-sqoop
+++ b/bin/configure-sqoop
@@ -34,8 +34,15 @@ fi
 
 SQOOP_CONF_DIR=${SQOOP_CONF_DIR:-${SQOOP_HOME}/conf}
 
-if [ -f "${SQOOP_CONF_DIR}/sqoop-env.sh" ]; then
-  . "${SQOOP_CONF_DIR}/sqoop-env.sh"
+# Source the corresponding environment config for Sqoop Metastore or client
+
+if [ "$SQOOP_NAME" = "sqoop-metastore" ]; then
+  if [ -f "${SQOOP_CONF_DIR}/sqoop-metastore-env.sh" ]; then
+    . "${SQOOP_CONF_DIR}/sqoop-metastore-env.sh"
+  fi
+else
+  if [ -f "${SQOOP_CONF_DIR}/sqoop-env.sh" ]; then
+    . "${SQOOP_CONF_DIR}/sqoop-env.sh"
 fi
 
 # Find paths to our dependency systems. If they are unset, use CDH defaults.
@@ -65,37 +72,18 @@ fi
 
 # We are setting HADOOP_HOME to HADOOP_COMMON_HOME if it is not set
 # so that hcat script works correctly on BigTop
-if [ -z "${HADOOP_HOME}" ]; then
-  if [ -n "${HADOOP_COMMON_HOME}" ]; then
-     HADOOP_HOME=${HADOOP_COMMON_HOME}
-     export HADOOP_HOME
-  fi
-fi
+#if [ -z "${HADOOP_HOME}" ]; then
+#  if [ -n "${HADOOP_COMMON_HOME}" ]; then
+#     HADOOP_HOME=${HADOOP_COMMON_HOME}
+#     export HADOOP_HOME
+#  fi
+#fi
 
 if [ -z "${HBASE_HOME}" ]; then
   if [ -d "/usr/lib/hbase" ]; then
     HBASE_HOME=/usr/lib/hbase
   else
     HBASE_HOME=${SQOOP_HOME}/../hbase
-  fi
-fi
-if [ -z "${HCAT_HOME}" ]; then
-  if [ -d "/usr/lib/hive-hcatalog" ]; then
-    HCAT_HOME=/usr/lib/hive-hcatalog
-  elif [ -d "/usr/lib/hcatalog" ]; then
-    HCAT_HOME=/usr/lib/hcatalog
-  else
-    HCAT_HOME=${SQOOP_HOME}/../hive-hcatalog
-    if [ ! -d ${HCAT_HOME} ]; then
-       HCAT_HOME=${SQOOP_HOME}/../hcatalog
-    fi
-  fi
-fi
-if [ -z "${ACCUMULO_HOME}" ]; then
-  if [ -d "/usr/lib/accumulo" ]; then
-    ACCUMULO_HOME=/usr/lib/accumulo
-  else
-    ACCUMULO_HOME=${SQOOP_HOME}/../accumulo
   fi
 fi
 if [ -z "${ZOOKEEPER_HOME}" ]; then
@@ -132,15 +120,6 @@ if [ ! -d "${HBASE_HOME}" ]; then
 fi
 
 ## Moved to be a runtime check in sqoop.
-if [ ! -d "${HCAT_HOME}" ]; then
-  echo "Warning: $HCAT_HOME does not exist! HCatalog jobs will fail."
-  echo 'Please set $HCAT_HOME to the root of your HCatalog installation.'
-fi
-
-if [ ! -d "${ACCUMULO_HOME}" ]; then
-  echo "Warning: $ACCUMULO_HOME does not exist! Accumulo imports will fail."
-  echo 'Please set $ACCUMULO_HOME to the root of your Accumulo installation.'
-fi
 if [ ! -d "${ZOOKEEPER_HOME}" ]; then
   echo "Warning: $ZOOKEEPER_HOME does not exist! Accumulo imports will fail."
   echo 'Please set $ZOOKEEPER_HOME to the root of your Zookeeper installation.'
@@ -176,24 +155,6 @@ if [ -e "$HBASE_HOME/bin/hbase" ]; then
   SQOOP_CLASSPATH=${TMP_SQOOP_CLASSPATH}
 fi
 
-# Add HCatalog to dependency list
-if [ -e "${HCAT_HOME}/bin/hcat" ]; then
-  TMP_SQOOP_CLASSPATH=${SQOOP_CLASSPATH}:`${HCAT_HOME}/bin/hcat -classpath`
-  if [ -z "${HIVE_CONF_DIR}" ]; then
-    TMP_SQOOP_CLASSPATH=${TMP_SQOOP_CLASSPATH}:${HIVE_CONF_DIR}
-  fi
-  SQOOP_CLASSPATH=${TMP_SQOOP_CLASSPATH}
-fi
-
-# Add Accumulo to dependency list
-if [ -e "$ACCUMULO_HOME/bin/accumulo" ]; then
-  for jn in `$ACCUMULO_HOME/bin/accumulo classpath | grep file:.*accumulo.*jar | cut -d':' -f2`; do
-    SQOOP_CLASSPATH=$SQOOP_CLASSPATH:$jn
-  done
-  for jn in `$ACCUMULO_HOME/bin/accumulo classpath | grep file:.*zookeeper.*jar | cut -d':' -f2`; do
-    SQOOP_CLASSPATH=$SQOOP_CLASSPATH:$jn
-  done
-fi
 
 ZOOCFGDIR=${ZOOCFGDIR:-/etc/zookeeper}
 if [ -d "${ZOOCFGDIR}" ]; then
@@ -225,7 +186,5 @@ export HADOOP_CLASSPATH
 export HADOOP_COMMON_HOME
 export HADOOP_MAPRED_HOME
 export HBASE_HOME
-export HCAT_HOME
 export HIVE_CONF_DIR
-export ACCUMULO_HOME
 export ZOOKEEPER_HOME

--- a/bin/configure-sqoop
+++ b/bin/configure-sqoop
@@ -43,6 +43,7 @@ if [ "$SQOOP_NAME" = "sqoop-metastore" ]; then
 else
   if [ -f "${SQOOP_CONF_DIR}/sqoop-env.sh" ]; then
     . "${SQOOP_CONF_DIR}/sqoop-env.sh"
+  fi
 fi
 
 # Find paths to our dependency systems. If they are unset, use CDH defaults.

--- a/bin/stop-metastore.sh
+++ b/bin/stop-metastore.sh
@@ -42,14 +42,19 @@ if [ -z "${pidfilename}" ]; then
   exit 1
 fi
 
+# Export service name for applying corresponding *-env.sh in configure-sqoop
+
+SQOOP_NAME=sqoop-metastore
+export SQOOP_NAME
+
+
 # Shut down any running metastore.
 
 if [ ! -z "$bin" ]; then
   bin="$bin/"
 fi
 
-HADOOP_ROOT_LOGGER=${HADOOP_ROOT_LOGGER:-ERROR,console} \
-    "$bin/sqoop" metastore --shutdown 2>&1 >/dev/null
+nohup "$bin/sqoop" metastore --shutdown 2>&1 >/dev/null
 ret=$?
 if [ "$ret" != "0" ]; then
   echo "Could not shut down metastore."


### PR DESCRIPTION
1. Removed hardcoded logging properties from Sqoop bin
2. Added condition for sourcing separate environment configs for Metastore and client 
3. Removed Hcat and Accumulo exports, warnings etc
4. Commented HADOOP_COMMON_HOME env variable required for hcat only *